### PR TITLE
Workaround for event source mapping provider issue

### DIFF
--- a/.changeset/giant-laws-mate.md
+++ b/.changeset/giant-laws-mate.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/cdktf-aws-adaptor": patch
+---
+
+workaround event source provider issue

--- a/src/__tests__/mappings/__snapshots__/lambda.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/lambda.spec.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`Lambda mappings > Should map AWS::Lambda::EventSourceMapping 1`] = `
 "{
+  \\"locals\\": {
+    \\"resource_selfmanaged-kafka-bootstrap-servers_C65ED52F\\": \\"\${jsonencode({\\\\\\"KAFKA_BOOTSTRAP_SERVERS\\\\\\" = join(\\\\\\",\\\\\\", [\\\\\\"kafkaBootstrapServers\\\\\\"])})}\\"
+  },
   \\"provider\\": {
     \\"aws\\": [
       {
@@ -52,9 +55,7 @@ exports[`Lambda mappings > Should map AWS::Lambda::EventSourceMapping 1`] = `
           \\"maximum_concurrency\\": 1
         },
         \\"self_managed_event_source\\": {
-          \\"endpoints\\": {
-            \\"KAFKA_BOOTSTRAP_SERVERS\\": \\"\${join(\\\\\\",\\\\\\", [\\\\\\"kafkaBootstrapServers\\\\\\"])}\\"
-          }
+          \\"endpoints\\": \\"\${jsondecode(local.resource_selfmanaged-kafka-bootstrap-servers_C65ED52F)}\\"
         },
         \\"self_managed_kafka_event_source_config\\": {
           \\"consumer_group_id\\": \\"consumerGroupId\\"


### PR DESCRIPTION
### Problem

Provider was generating insonsistent value issue when using event source mapping

### Solution

Use intermediate terraform local to avoid the issue

#### Test Plan:
- [ ] Covered by existing tests
- [ ] New coverage added
- [ ] Special instructions for testing described below

<!--- Describe how to test this PR -->

#### Documentation:
- [ ] No documentation required
- [ ] Additional documentation required below

<!--- Describe any additional documentation required -->

#### Additional Notes:

N/A <!--- Describe any additional notes or context -->
