### PR TITLE
Fix for resolving provider field

### DIFF
--- a/.changeset/poor-flowers-repeat.md
+++ b/.changeset/poor-flowers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/cdktf-aws-adaptor": patch
+---
+
+fix for trying to resolve provider field

--- a/src/__tests__/cdk-adaptor-stack.spec.ts
+++ b/src/__tests__/cdk-adaptor-stack.spec.ts
@@ -1,6 +1,7 @@
 import { AppsyncGraphqlApi } from "@cdktf/provider-aws/lib/appsync-graphql-api/index.js";
 import { CloudcontrolapiResource } from "@cdktf/provider-aws/lib/cloudcontrolapi-resource/index.js";
 import { IamRole } from "@cdktf/provider-aws/lib/iam-role/index.js";
+import { AwsProvider } from "@cdktf/provider-aws/lib/provider/index.js";
 import { S3BucketPolicy } from "@cdktf/provider-aws/lib/s3-bucket-policy/index.js";
 import { S3Bucket } from "@cdktf/provider-aws/lib/s3-bucket/index.js";
 import { S3Object } from "@cdktf/provider-aws/lib/s3-object/index.js";
@@ -246,6 +247,20 @@ describe("Stack synthesis", () => {
             expect(synthesized).toHaveResourceWithProperties(S3Bucket, {
                 bucket: "cdktf-test-bucket",
             });
+        });
+
+        it("Should synthesize explicit provider specification", () => {
+            const testApp = Testing.app();
+            class TestStackWithCustomProvider extends AwsTerraformAdaptorStack {
+                public readonly testProvider = new AwsProvider(this, "test-provider");
+                public readonly bucket = new S3Bucket(this, "bucket", {
+                    bucket: "cool-bucket",
+                    provider: this.testProvider,
+                });
+            }
+            const testStack = new TestStackWithCustomProvider(testApp, "test-stack-3", {});
+            testStack.prepareStack();
+            expect(Testing.synth.bind(Testing, testStack)).not.toThrow();
         });
     });
 

--- a/src/lib/core/cdk-adaptor-stack.ts
+++ b/src/lib/core/cdk-adaptor-stack.ts
@@ -22,6 +22,7 @@ import {
     TerraformElement,
     TerraformLocal,
     TerraformOutput,
+    TerraformProvider,
     TerraformResource,
     TerraformStack,
     TerraformVariable,
@@ -320,13 +321,15 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
                 || tKey === "node"
                 || tKey === "fqn"
                 || tKey === "friendlyUniqueId"
-                || tKey === "provider"
                 || tKey === "terraformResourceType"
                 || tKey === "terraformGeneratorMetadata"
                 || tKey === "terraformMetaArguments"
             ) continue;
 
-            if (typeof value === "function" || isConstruct(value) || value == null) continue;
+            if (
+                typeof value === "function" || isConstruct(value) || value == null || value instanceof TerraformResource
+                || value instanceof TerraformProvider
+            ) continue;
             if (value["internalValue"] == null) {
                 const resolvedValue = this.host.resolve(value);
                 const intrinsicsProcessedValue = this.processIntrinsics(resolvedValue);

--- a/src/lib/core/cdk-adaptor-stack.ts
+++ b/src/lib/core/cdk-adaptor-stack.ts
@@ -312,14 +312,18 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
         }
     }
 
-    private resolveTerraformElement(element: TerraformElement) {
+    private resolveTerraformElement(element: TerraformResource) {
         for (const [key, value] of Object.entries(element)) {
-            const tKey = key as keyof TerraformElement;
+            const tKey = key as keyof TerraformResource;
             if (
                 tKey === "cdktfStack"
                 || tKey === "node"
                 || tKey === "fqn"
                 || tKey === "friendlyUniqueId"
+                || tKey === "provider"
+                || tKey === "terraformResourceType"
+                || tKey === "terraformGeneratorMetadata"
+                || tKey === "terraformMetaArguments"
             ) continue;
 
             if (typeof value === "function" || isConstruct(value) || value == null) continue;

--- a/src/lib/core/cdk-adaptor-stack.ts
+++ b/src/lib/core/cdk-adaptor-stack.ts
@@ -313,22 +313,20 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
         }
     }
 
-    private resolveTerraformElement(element: TerraformResource) {
+    private resolveTerraformElement(element: TerraformElement) {
         for (const [key, value] of Object.entries(element)) {
-            const tKey = key as keyof TerraformResource;
+            const tKey = key as keyof TerraformElement;
             if (
                 tKey === "cdktfStack"
                 || tKey === "node"
                 || tKey === "fqn"
                 || tKey === "friendlyUniqueId"
-                || tKey === "terraformResourceType"
-                || tKey === "terraformGeneratorMetadata"
-                || tKey === "terraformMetaArguments"
             ) continue;
 
             if (
-                typeof value === "function" || isConstruct(value) || value == null || value instanceof TerraformResource
-                || value instanceof TerraformProvider
+                typeof value === "function" || isConstruct(value) || value == null
+                || TerraformResource.isTerraformResource(value)
+                || TerraformProvider.isTerraformProvider(value)
             ) continue;
             if (value["internalValue"] == null) {
                 const resolvedValue = this.host.resolve(value);


### PR DESCRIPTION
### Problem

Currently, an exception is thrown when a construct specifies a provider field.

### Solution

Fields that contain TerraformResources should be excluded from resolution

#### Test Plan:
- [ ] Covered by existing tests
- [x] New coverage added
- [ ] Special instructions for testing described below

<!--- Describe how to test this PR -->

#### Documentation:
- [x] No documentation required
- [ ] Additional documentation required below

<!--- Describe any additional documentation required -->

#### Additional Notes:

N/A <!--- Describe any additional notes or context -->
