### PR TITLE
fix inverted dependency synthesis

### DIFF
--- a/.changeset/chilled-buttons-fail.md
+++ b/.changeset/chilled-buttons-fail.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/cdktf-aws-adaptor": patch
+---
+
+fix issue with inverted dependency synthesis

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@typescript-eslint/parser": "^6.21.0",
     "@vitest/coverage-v8": "^0.34.6",
     "aws-cdk-lib": "^2.132.0",
-    "cdktf": "^0.20.4",
+    "cdktf": "^0.20.8",
     "cdktf-cli": "^0.18.2",
     "constructs": "^10.3.0",
     "dprint": "^0.35.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   camel-case:
     specifier: ^4.1.2
@@ -20,7 +24,7 @@ devDependencies:
     version: 3.515.0
   '@cdktf/provider-aws':
     specifier: ^19.9.0
-    version: 19.9.0(cdktf@0.20.4)(constructs@10.3.0)
+    version: 19.9.0(cdktf@0.20.8)(constructs@10.3.0)
   '@changesets/cli':
     specifier: ^2.27.1
     version: 2.27.1
@@ -46,8 +50,8 @@ devDependencies:
     specifier: ^2.132.0
     version: 2.132.0(constructs@10.3.0)
   cdktf:
-    specifier: ^0.20.4
-    version: 0.20.4(constructs@10.3.0)
+    specifier: ^0.20.8
+    version: 0.20.8(constructs@10.3.0)
   cdktf-cli:
     specifier: ^0.18.2
     version: 0.18.2(debug@4.3.4)(ink@3.2.0)(react@17.0.2)
@@ -778,14 +782,14 @@ packages:
       prebuild-install: 7.1.1
     dev: true
 
-  /@cdktf/provider-aws@19.9.0(cdktf@0.20.4)(constructs@10.3.0):
+  /@cdktf/provider-aws@19.9.0(cdktf@0.20.8)(constructs@10.3.0):
     resolution: {integrity: sha512-6dv48W08rINuf4L2VE25h9Ya48RO34QjERshM9rF+xArUWK43ED0eofRg52jftsJKFxf01zEsX6UGw35AysciQ==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       cdktf: ^0.20.0
       constructs: ^10.3.0
     dependencies:
-      cdktf: 0.20.4(constructs@10.3.0)
+      cdktf: 0.20.8(constructs@10.3.0)
       constructs: 10.3.0
     dev: true
 
@@ -2767,10 +2771,10 @@ packages:
       - json-stable-stringify
       - semver
 
-  /cdktf@0.20.4(constructs@10.3.0):
-    resolution: {integrity: sha512-4vgJ8TLik1xse5B8gMcWoE2DkdnkhiTVVyvE+j7dNoCpDApqkINY8MpiZjgCQ4HQ2H/wjRrVAD80bV9JaHixRQ==}
+  /cdktf@0.20.8(constructs@10.3.0):
+    resolution: {integrity: sha512-O4O5h0b1E6scc/tqq9EUIQGDbPmdrCQpdkPdbDtUHHzhZGtmFpIMc5MgP1SgB+EzAutnG2oUDefjCqWMnhDe9A==}
     peerDependencies:
-      constructs: ^10.0.25
+      constructs: ^10.3.0
     dependencies:
       constructs: 10.3.0
     dev: true
@@ -3227,7 +3231,7 @@ packages:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240311
+      typescript: 5.6.0-dev.20240702
     dev: true
 
   /dprint@0.35.4:
@@ -6245,8 +6249,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.5.0-dev.20240311:
-    resolution: {integrity: sha512-Cdp0eYgn/19lkcrq7WCqQxmnvCqvuJrd/jGhm1HyPMSYVTGzjxVP0NfXr2A4YVS12IAipt1uO4zgAJeLlYG2JA==}
+  /typescript@5.6.0-dev.20240702:
+    resolution: {integrity: sha512-hbRazJD/2++Y7fBv6NZtCyoMfoVYmuDlGs+jqdWicZfXP6Fp8q9FDFnuvYpKNq1fXwBrGIUXEZlXssvXIWy/FQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -6704,7 +6708,3 @@ packages:
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/src/__tests__/cdk-adaptor-stack.spec.ts
+++ b/src/__tests__/cdk-adaptor-stack.spec.ts
@@ -497,6 +497,46 @@ describe("Stack synthesis", () => {
                     `$\{data.terraform_remote_state.cross-stack-reference-input-test-stack-12-aws-stage--test-stack-12-aws-stack--test-stack-12.outputs.cross-stack-output-${bucketNameOutputRef}}`,
             });
         });
+
+        it("Should support inter-stack references with inverted constructor order", () => {
+            const testApp = Testing.app({
+                outdir: dirname,
+            });
+            class TestStack1 extends AwsTerraformAdaptorStack {
+                public lambda = new Function(this, "lambda", {
+                    code: Code.fromInline("console.log('yay')"),
+                    handler: "index.handler",
+                    runtime: Runtime.NODEJS_LATEST,
+                });
+
+                constructor() {
+                    super(testApp, "test-stack-14", {});
+                }
+            }
+            const testStack1 = new TestStack1();
+
+            class TestStack2 extends AwsTerraformAdaptorStack {
+                public readonly role = new IamRole(this, "role", {
+                    name: testStack1.lambda.functionName + "2",
+                    assumeRolePolicy: "",
+                });
+                constructor() {
+                    super(testApp, "test-stack-15", {});
+                }
+            }
+            const testStack2 = new TestStack2();
+
+            testStack2.prepareStack();
+            testStack1.prepareStack();
+
+            const synthesized2 = Testing.synth(testStack2);
+            Testing.synth(testStack1);
+
+            expect(synthesized2).toHaveResourceWithProperties(IamRole, {
+                name:
+                    "${join(\"\", [data.terraform_remote_state.cross-stack-reference-input-test-stack-14-aws-stage--test-stack-14-aws-stack--test-stack-14.outputs.cross-stack-output-aws_lambda_functionlambda_8B5974B5id, \"2\"])}",
+            });
+        });
     });
 
     describe("File assets", () => {

--- a/src/lib/core/cdk-adaptor-stack.ts
+++ b/src/lib/core/cdk-adaptor-stack.ts
@@ -161,8 +161,6 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
         this.awsStage = awsStage;
         this.host = awsCdkStack;
 
-        // this.injectAppHook(App.of(this))
-
         addCustomSynthesis(this, {
             onSynthesize: (session) => {
                 const manifest = session.manifest.forStack(this);

--- a/src/lib/core/cdk-adaptor-stack.ts
+++ b/src/lib/core/cdk-adaptor-stack.ts
@@ -14,6 +14,7 @@ import {
     Token as AWSToken,
 } from "aws-cdk-lib";
 import {
+    App,
     Aspects,
     dependable,
     Fn,
@@ -68,8 +69,11 @@ function getConditionConstructId(conditionId: string) {
     return `condition_${conditionId}`;
 }
 
+const IS_APP_CONVERTED = Symbol("IS_APP_SYNTH_HOOKED");
+
 export abstract class AwsTerraformAdaptorStack extends TerraformStack {
     public readonly useCloudControlFallback: boolean;
+    private isConverted = false;
     private readonly awsStage: AWSStage;
     private readonly host: AWSStack;
     private _awsPartition?: DataAwsPartition;
@@ -157,6 +161,8 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
         this.awsStage = awsStage;
         this.host = awsCdkStack;
 
+        // this.injectAppHook(App.of(this))
+
         addCustomSynthesis(this, {
             onSynthesize: (session) => {
                 const manifest = session.manifest.forStack(this);
@@ -237,10 +243,30 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
         cdkTokenResolutionCompat.enableUnresolvedTfTokens();
     }
 
+    private convertOnce() {
+        if (!this.isConverted) {
+            cdkTokenResolutionCompat.disableUnresolvedTfTokens();
+            this.convert();
+            cdkTokenResolutionCompat.enableUnresolvedTfTokens();
+            this.isConverted = true;
+        }
+    }
+
+    private convertAllSiblingStacks() {
+        const app = App.of(this);
+        if ((app as any)[IS_APP_CONVERTED] !== true) {
+            const stacks = app.node.findAll().filter((child) =>
+                child instanceof AwsTerraformAdaptorStack
+            ) as AwsTerraformAdaptorStack[];
+            for (const stack of stacks) {
+                stack.convertOnce();
+            }
+            (app as any)[IS_APP_CONVERTED] = true;
+        }
+    }
+
     prepareStack() {
-        cdkTokenResolutionCompat.disableUnresolvedTfTokens();
-        this.convert();
-        cdkTokenResolutionCompat.enableUnresolvedTfTokens();
+        this.convertAllSiblingStacks();
         super.prepareStack();
         this.resolveCfnInTokenMap();
     }
@@ -322,7 +348,12 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
                 || tKey === "friendlyUniqueId"
             ) continue;
 
-            if (typeof value === "function" || isConstruct(value) || value == null) continue;
+            if (
+                typeof value === "function"
+                || isConstruct(value)
+                || value == null
+                || value.crossStackIdentifier != null
+            ) continue;
             if (value["internalValue"] == null) {
                 const resolvedValue = this.host.resolve(value);
                 const intrinsicsProcessedValue = this.processIntrinsics(resolvedValue);
@@ -579,6 +610,9 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
         if (!mapping) {
             // Don't be infinitely lazy
             if (isLazy) {
+                // if the reference can't be resolved at this point, it almost certainly a reference to a resource in another stack that hasn't been converted yet
+                //
+
                 throw new Error(
                     `unable to resolve a "Ref" to a resource with the logical ID ${logicalId}`,
                 );
@@ -803,8 +837,6 @@ export abstract class AwsTerraformAdaptorStack extends TerraformStack {
 
             case "Fn::ImportValue": {
                 // TODO: support cross cfn stack references?
-                // This is related to the Export Name from outputs https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html
-                // We might revisit this once the CDKTF supports cross stack references
                 throw new Error(`Fn::ImportValue is not yet supported.`);
             }
 


### PR DESCRIPTION
### Problem

Synthesis throws an error when a stack references a cloudformation value from a yet-to-be converted stack

### Solution

Use a singleton hook in `prepareStack` to ensure that all stacks are converted *before* other preparations take place

#### Test Plan:
- [ ] Covered by existing tests
- [x] New coverage added
- [ ] Special instructions for testing described below

<!--- Describe how to test this PR -->

#### Documentation:
- [x] No documentation required
- [ ] Additional documentation required below

<!--- Describe any additional documentation required -->

#### Additional Notes:

N/A <!--- Describe any additional notes or context -->
