### PR TITLE
Fixes for S3 Bucket and Cloudfront Distribution constructs

### DIFF
--- a/.changeset/late-papayas-push.md
+++ b/.changeset/late-papayas-push.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/cdktf-aws-adaptor": patch
+---
+
+Fix case inconsistency for S3 Bucket `WebsiteUrl` param, add defaults for some CloudFront Distribution params

--- a/src/mappings/cfn-mapper-types.ts
+++ b/src/mappings/cfn-mapper-types.ts
@@ -114,6 +114,7 @@ type ConvertScriptKeySuffix<T extends string> = T extends `${infer U}Arns` ? `${
 type ConvertAnnoyingSpecialCases<T extends string> = T extends "DefaultRedirectUri" ? "DefaultRedirectURI"
     : T extends "ManagedPolicyARNs" ? "ManagedPolicyArns"
     : T extends "ProviderUrl" ? "ProviderURL"
+    : T extends "WebsiteUrl" ? "WebsiteURL"
     : T extends "" ? never
     : T;
 

--- a/src/mappings/services/cloudfront.ts
+++ b/src/mappings/services/cloudfront.ts
@@ -106,8 +106,8 @@ export function registerCloudfrontMappings() {
                     connectionAttempts: origin.ConnectionAttempts,
                     connectionTimeout: origin.ConnectionTimeout,
                     customOriginConfig: {
-                        httpPort: origin.CustomOriginConfig?.HTTPPort as number,
-                        httpsPort: origin.CustomOriginConfig?.HTTPSPort as number,
+                        httpPort: origin.CustomOriginConfig?.HTTPPort as number || 80,
+                        httpsPort: origin.CustomOriginConfig?.HTTPSPort as number || 443,
                         originKeepaliveTimeout: origin.CustomOriginConfig?.OriginKeepaliveTimeout,
                         originProtocolPolicy: origin.CustomOriginConfig?.OriginProtocolPolicy as string,
                         originReadTimeout: origin.CustomOriginConfig?.OriginReadTimeout,
@@ -136,7 +136,7 @@ export function registerCloudfrontMappings() {
                 restrictions: {
                     geoRestriction: {
                         restrictionType: props.DistributionConfig.Restrictions?.GeoRestriction
-                            ?.RestrictionType as string,
+                            ?.RestrictionType as string || "none",
                         locations: props.DistributionConfig.Restrictions?.GeoRestriction?.Locations,
                     },
                 },

--- a/src/mappings/services/s3.ts
+++ b/src/mappings/services/s3.ts
@@ -424,7 +424,7 @@ export function registerS3Mappings() {
                 const region = bucket.region;
                 return `${bucket.bucket}.s3.dualstack.${region}.amazonaws.com`;
             },
-            WebsiteUrl: (bucket: S3Bucket) => {
+            WebsiteURL: (bucket: S3Bucket) => {
                 const website =
                     (bucket as unknown as { [BUCKET_WEB_SITE]: S3BucketWebsiteConfiguration })[BUCKET_WEB_SITE];
                 return website ? website.websiteEndpoint : "";


### PR DESCRIPTION
### Problem / Solution

Another case issue where AWS inconsistently cases the parameter "WebsiteUrl" (vs. "WebsiteURL").
Also, there are some params for `CloudfrontDistributionConfig` that are optional in CDK, but required in Terraform, so add defaults for those.

#### Test Plan:
- [X] Covered by existing tests
- [ ] New coverage added
- [ ] Special instructions for testing described below

<!--- Describe how to test this PR -->

#### Documentation:
- [ ] No documentation required
- [ ] Additional documentation required below

<!--- Describe any additional documentation required -->

#### Additional Notes:

N/A <!--- Describe any additional notes or context -->
