### PR TITLE
fix: set custom origin config to undefined if props does not define it

### DIFF
--- a/.changeset/strange-mugs-exist.md
+++ b/.changeset/strange-mugs-exist.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/cdktf-aws-adaptor": patch
+---
+
+Fix default property for Cloudfront distribution always setting custom origin config

--- a/src/__tests__/mappings/__snapshots__/cloudfront.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/cloudfront.spec.ts.snap
@@ -277,3 +277,132 @@ exports[`CloudFront > Should map AWS::CloudFront::Distribution 1`] = `
   }
 }"
 `;
+
+exports[`CloudFront > Should map AWS::CloudFront::Distribution 2`] = `
+"{
+  \\"provider\\": {
+    \\"aws\\": [
+      {
+        \\"alias\\": \\"us_east_1\\",
+        \\"region\\": \\"us-east-1\\"
+      }
+    ]
+  },
+  \\"resource\\": {
+    \\"aws_cloudfront_distribution\\": {
+      \\"resource_22C949BF\\": {
+        \\"default_cache_behavior\\": {
+          \\"allowed_methods\\": [
+            \\"GET\\",
+            \\"HEAD\\"
+          ],
+          \\"cache_policy_id\\": \\"658327ea-f89d-4fab-a63d-7e88639e58f6\\",
+          \\"cached_methods\\": [
+            \\"GET\\",
+            \\"HEAD\\"
+          ],
+          \\"compress\\": true,
+          \\"default_ttl\\": 3600,
+          \\"field_level_encryption_id\\": \\"1234567890abcdef1234567890abcdef\\",
+          \\"forwarded_values\\": {
+            \\"cookies\\": {
+              \\"forward\\": \\"none\\"
+            },
+            \\"headers\\": [
+              \\"*\\"
+            ],
+            \\"query_string\\": false,
+            \\"query_string_cache_keys\\": [
+              \\"*\\"
+            ]
+          },
+          \\"function_association\\": [
+            {
+              \\"event_type\\": \\"viewer-request\\",
+              \\"function_arn\\": \\"arn:aws:lambda:us-east-1:111111111111:function:my-function\\"
+            }
+          ],
+          \\"lambda_function_association\\": [
+            {
+              \\"event_type\\": \\"origin-request\\",
+              \\"include_body\\": true,
+              \\"lambda_arn\\": \\"arn:aws:lambda:us-east-1:111111111111:function:my-function\\"
+            }
+          ],
+          \\"max_ttl\\": 86400,
+          \\"min_ttl\\": 0,
+          \\"origin_request_policy_id\\": \\"658327ea-f89d-4fab-a63d-7e88639e58f6\\",
+          \\"realtime_log_config_arn\\": \\"arn:aws:logs:us-east-1:111111111111:realtime-log-config/my-distribution\\",
+          \\"response_headers_policy_id\\": \\"658327ea-f89d-4fab-a63d-7e88639e58f6\\",
+          \\"smooth_streaming\\": true,
+          \\"target_origin_id\\": \\"my-target-origin\\",
+          \\"trusted_key_groups\\": [
+            \\"1234567890abcdef1234567890abcdef\\"
+          ],
+          \\"trusted_signers\\": [
+            \\"1234567890abcdef1234567890abcdef\\"
+          ],
+          \\"viewer_protocol_policy\\": \\"redirect-to-https\\"
+        },
+        \\"enabled\\": true,
+        \\"origin\\": [
+          {
+            \\"connection_attempts\\": 3,
+            \\"connection_timeout\\": 10,
+            \\"custom_header\\": [
+              {
+                \\"name\\": \\"MyCustomHeader\\",
+                \\"value\\": \\"MyCustomValue\\"
+              }
+            ],
+            \\"domain_name\\": \\"example.com\\",
+            \\"origin_access_control_id\\": \\"1234567890abcdef1234567890abcdef\\",
+            \\"origin_id\\": \\"my-origin\\",
+            \\"origin_path\\": \\"/mypath\\",
+            \\"origin_shield\\": {
+              \\"enabled\\": true
+            },
+            \\"s3_origin_config\\": {
+              \\"origin_access_identity\\": \\"origin-access-identity/cloudfront/E127EXAMPLE51Z\\"
+            }
+          }
+        ],
+        \\"restrictions\\": {
+          \\"geo_restriction\\": {
+            \\"locations\\": [
+              \\"US\\",
+              \\"CA\\",
+              \\"GB\\"
+            ],
+            \\"restriction_type\\": \\"whitelist\\"
+          }
+        },
+        \\"viewer_certificate\\": {
+          \\"acm_certificate_arn\\": \\"arn:aws:acm:us-east-1:111111111111:certificate/12345678-1234-1234-1234-123456789012\\",
+          \\"minimum_protocol_version\\": \\"TLSv1.2_2019\\",
+          \\"ssl_support_method\\": \\"sni-only\\"
+        }
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"backend\\": {
+      \\"local\\": {
+        \\"path\\": \\"/terraform.test-stack.tfstate\\"
+      }
+    },
+    \\"required_providers\\": {
+      \\"aws\\": {
+        \\"source\\": \\"aws\\",
+        \\"version\\": \\"5.40.0\\"
+      }
+    }
+  },
+  \\"variable\\": {
+    \\"resource_refs_CDA17697\\": {
+      \\"default\\": \\"\${join(\\\\\\"\\\\\\", [aws_cloudfront_distribution.resource_22C949BF.domain_name, \\\\\\",\\\\\\", aws_cloudfront_distribution.resource_22C949BF.id])}\\",
+      \\"type\\": \\"string\\"
+    }
+  }
+}"
+`;

--- a/src/__tests__/mappings/cloudfront.spec.ts
+++ b/src/__tests__/mappings/cloudfront.spec.ts
@@ -356,4 +356,159 @@ describe("CloudFront", () => {
             staging: true,
         },
     );
+
+    itShouldMapCfnElementToTerraformResource(
+        CfnDistribution,
+        {
+            distributionConfig: {
+                defaultCacheBehavior: {
+                    allowedMethods: ["GET", "HEAD"],
+                    cachedMethods: ["GET", "HEAD"],
+                    compress: true,
+                    defaultTtl: 3600,
+                    forwardedValues: {
+                        cookies: {
+                            forward: "none",
+                        },
+                        queryString: false,
+                        headers: ["*"],
+                        queryStringCacheKeys: ["*"],
+                    },
+                    cachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                    lambdaFunctionAssociations: [
+                        {
+                            eventType: "origin-request",
+                            lambdaFunctionArn: "arn:aws:lambda:us-east-1:111111111111:function:my-function",
+                            includeBody: true,
+                        },
+                    ],
+                    fieldLevelEncryptionId: "1234567890abcdef1234567890abcdef",
+                    maxTtl: 86400,
+                    minTtl: 0,
+                    originRequestPolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                    realtimeLogConfigArn: "arn:aws:logs:us-east-1:111111111111:realtime-log-config/my-distribution",
+                    responseHeadersPolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                    smoothStreaming: true,
+                    targetOriginId: "my-target-origin",
+                    trustedKeyGroups: ["1234567890abcdef1234567890abcdef"],
+                    functionAssociations: [
+                        {
+                            eventType: "viewer-request",
+                            functionArn: "arn:aws:lambda:us-east-1:111111111111:function:my-function",
+                        },
+                    ],
+                    trustedSigners: ["1234567890abcdef1234567890abcdef"],
+                    viewerProtocolPolicy: "redirect-to-https",
+                },
+                enabled: true,
+                restrictions: {
+                    geoRestriction: {
+                        restrictionType: "whitelist",
+                        locations: ["US", "CA", "GB"],
+                    },
+                },
+                viewerCertificate: {
+                    acmCertificateArn:
+                        "arn:aws:acm:us-east-1:111111111111:certificate/12345678-1234-1234-1234-123456789012",
+                    minimumProtocolVersion: "TLSv1.2_2019",
+                    sslSupportMethod: "sni-only",
+                },
+                origins: [{
+                    domainName: "example.com",
+                    id: "my-origin",
+                    connectionAttempts: 3,
+                    connectionTimeout: 10,
+                    originAccessControlId: "1234567890abcdef1234567890abcdef",
+                    originPath: "/mypath",
+                    originShield: {
+                        enabled: true,
+                    },
+                    originCustomHeaders: [{
+                        headerName: "MyCustomHeader",
+                        headerValue: "MyCustomValue",
+                    }],
+                    s3OriginConfig: {
+                        originAccessIdentity: "origin-access-identity/cloudfront/E127EXAMPLE51Z",
+                    },
+                }],
+            },
+        },
+        CloudfrontDistribution,
+        {
+            defaultCacheBehavior: {
+                allowedMethods: ["GET", "HEAD"],
+                cachedMethods: ["GET", "HEAD"],
+                compress: true,
+                defaultTtl: 3600,
+                forwardedValues: {
+                    cookies: {
+                        forward: "none",
+                    },
+                    queryString: false,
+                    headers: ["*"],
+                    queryStringCacheKeys: ["*"],
+                },
+                cachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                lambdaFunctionAssociation: [
+                    {
+                        eventType: "origin-request",
+                        lambdaArn: "arn:aws:lambda:us-east-1:111111111111:function:my-function",
+                        includeBody: true,
+                    },
+                ],
+                fieldLevelEncryptionId: "1234567890abcdef1234567890abcdef",
+                maxTtl: 86400,
+                minTtl: 0,
+                originRequestPolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                realtimeLogConfigArn: "arn:aws:logs:us-east-1:111111111111:realtime-log-config/my-distribution",
+                responseHeadersPolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                smoothStreaming: true,
+                targetOriginId: "my-target-origin",
+                trustedKeyGroups: ["1234567890abcdef1234567890abcdef"],
+                functionAssociation: [
+                    {
+                        eventType: "viewer-request",
+                        functionArn: "arn:aws:lambda:us-east-1:111111111111:function:my-function",
+                    },
+                ],
+                trustedSigners: ["1234567890abcdef1234567890abcdef"],
+                viewerProtocolPolicy: "redirect-to-https",
+            },
+            enabled: true,
+            restrictions: {
+                geoRestriction: {
+                    restrictionType: "whitelist",
+                    locations: ["US", "CA", "GB"],
+                },
+            },
+            viewerCertificate: {
+                acmCertificateArn:
+                    "arn:aws:acm:us-east-1:111111111111:certificate/12345678-1234-1234-1234-123456789012",
+                minimumProtocolVersion: "TLSv1.2_2019",
+                sslSupportMethod: "sni-only",
+            },
+            origin: [
+                {
+                    connectionAttempts: 3,
+                    connectionTimeout: 10,
+                    customHeader: [
+                        {
+                            name: "MyCustomHeader",
+                            value: "MyCustomValue",
+                        },
+                    ],
+                    domainName: "example.com",
+                    originAccessControlId: "1234567890abcdef1234567890abcdef",
+                    originId: "my-origin",
+                    originPath: "/mypath",
+                    originShield: {
+                        enabled: true,
+                    },
+                    s3OriginConfig: {
+                        originAccessIdentity: "origin-access-identity/cloudfront/E127EXAMPLE51Z",
+                    },
+                },
+            ],
+        },
+    );
 });

--- a/src/mappings/services/cloudfront.ts
+++ b/src/mappings/services/cloudfront.ts
@@ -105,14 +105,16 @@ export function registerCloudfrontMappings() {
                     })),
                     connectionAttempts: origin.ConnectionAttempts,
                     connectionTimeout: origin.ConnectionTimeout,
-                    customOriginConfig: {
-                        httpPort: origin.CustomOriginConfig?.HTTPPort as number || 80,
-                        httpsPort: origin.CustomOriginConfig?.HTTPSPort as number || 443,
-                        originKeepaliveTimeout: origin.CustomOriginConfig?.OriginKeepaliveTimeout,
-                        originProtocolPolicy: origin.CustomOriginConfig?.OriginProtocolPolicy as string,
-                        originReadTimeout: origin.CustomOriginConfig?.OriginReadTimeout,
-                        originSslProtocols: origin.CustomOriginConfig?.OriginSSLProtocols as string[],
-                    },
+                    customOriginConfig: origin.CustomOriginConfig
+                        ? {
+                            httpPort: origin.CustomOriginConfig.HTTPPort ?? 80,
+                            httpsPort: origin.CustomOriginConfig.HTTPSPort ?? 443,
+                            originKeepaliveTimeout: origin.CustomOriginConfig.OriginKeepaliveTimeout,
+                            originProtocolPolicy: origin.CustomOriginConfig.OriginProtocolPolicy,
+                            originReadTimeout: origin.CustomOriginConfig.OriginReadTimeout,
+                            originSslProtocols: origin.CustomOriginConfig.OriginSSLProtocols as string[],
+                        }
+                        : undefined,
                     originPath: origin.OriginPath,
                     originAccessControlId: origin.OriginAccessControlId,
                     originShield: {


### PR DESCRIPTION
### Problem

Custom origin config was always being set due to erroneous defaulting of properties

### Solution

Only default and define the custom origin config property if the incoming property defines it

#### Test Plan:
- [ ] Covered by existing tests
- [x] New coverage added
- [ ] Special instructions for testing described below

<!--- Describe how to test this PR -->

#### Documentation:
- [ ] No documentation required
- [ ] Additional documentation required below

<!--- Describe any additional documentation required -->

#### Additional Notes:

N/A <!--- Describe any additional notes or context -->
