### PR TITLE
support dynamodb resource policy

### DIFF
--- a/.changeset/soft-walls-share.md
+++ b/.changeset/soft-walls-share.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/cdktf-aws-adaptor": minor
+---
+
+add support for dynamodb resource policies

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "license": "MIT",
   "devDependencies": {
     "@aws-sdk/client-cloudformation": "^3.515.0",
-    "@cdktf/provider-aws": "^19.9.0",
+    "@cdktf/provider-aws": "^19.28.0",
     "@changesets/cli": "^2.27.1",
     "@eslint/js": "^8.56.0",
     "@types/debug": "^4.1.12",
@@ -62,7 +62,7 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "@vitest/coverage-v8": "^0.34.6",
-    "aws-cdk-lib": "^2.132.0",
+    "aws-cdk-lib": "^2.150.0",
     "cdktf": "^0.20.8",
     "cdktf-cli": "^0.18.2",
     "constructs": "^10.3.0",
@@ -74,8 +74,8 @@
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "@cdktf/provider-aws": ">=19.0.0",
-    "aws-cdk-lib": ">=2.101.0",
+    "@cdktf/provider-aws": ">=19.28.0",
+    "aws-cdk-lib": ">=2.150.0",
     "cdktf": "^0.20.4",
     "constructs": "^10.2.69"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ devDependencies:
     specifier: ^3.515.0
     version: 3.515.0
   '@cdktf/provider-aws':
-    specifier: ^19.9.0
-    version: 19.9.0(cdktf@0.20.8)(constructs@10.3.0)
+    specifier: ^19.28.0
+    version: 19.28.0(cdktf@0.20.8)(constructs@10.3.0)
   '@changesets/cli':
     specifier: ^2.27.1
     version: 2.27.1
@@ -47,8 +47,8 @@ devDependencies:
     specifier: ^0.34.6
     version: 0.34.6(vitest@0.34.6)
   aws-cdk-lib:
-    specifier: ^2.132.0
-    version: 2.132.0(constructs@10.3.0)
+    specifier: ^2.150.0
+    version: 2.150.0(constructs@10.3.0)
   cdktf:
     specifier: ^0.20.8
     version: 0.20.8(constructs@10.3.0)
@@ -100,8 +100,8 @@ packages:
     resolution: {integrity: sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==}
     dev: true
 
-  /@aws-cdk/asset-node-proxy-agent-v6@2.0.1:
-    resolution: {integrity: sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==}
+  /@aws-cdk/asset-node-proxy-agent-v6@2.0.3:
+    resolution: {integrity: sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==}
     dev: true
 
   /@aws-crypto/crc32@3.0.0:
@@ -782,8 +782,8 @@ packages:
       prebuild-install: 7.1.1
     dev: true
 
-  /@cdktf/provider-aws@19.9.0(cdktf@0.20.8)(constructs@10.3.0):
-    resolution: {integrity: sha512-6dv48W08rINuf4L2VE25h9Ya48RO34QjERshM9rF+xArUWK43ED0eofRg52jftsJKFxf01zEsX6UGw35AysciQ==}
+  /@cdktf/provider-aws@19.28.0(cdktf@0.20.8)(constructs@10.3.0):
+    resolution: {integrity: sha512-7VNR/KOUtRySdDw/pIT1ZAHI+fdWZvmHO5XI5GmejmKR3UAt+kvQIFzsKcBkyYzmJUkmwoyVnG/RykUS99nqUg==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       cdktf: ^0.20.0
@@ -2575,15 +2575,15 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /aws-cdk-lib@2.132.0(constructs@10.3.0):
-    resolution: {integrity: sha512-auztTTYy8j62MmRZNdM7Vd8eQ5eP3xLMhrrILhDZf3DiSDD0lyYL0hv98VD4XPkWGMQ8yOmo5nZ3s/zD7cnKlw==}
+  /aws-cdk-lib@2.150.0(constructs@10.3.0):
+    resolution: {integrity: sha512-A5dJ6iIAXlkSgUIKhhSd5slEjvDBiREv6/xw8CgrXU+puoFULu5bC0SOQARjTzcsAgAVtxdlaZ7qy7u9It7nHQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.202
       '@aws-cdk/asset-kubectl-v20': 2.1.2
-      '@aws-cdk/asset-node-proxy-agent-v6': 2.0.1
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.0.3
       constructs: 10.3.0
     dev: true
     bundledDependencies:
@@ -3231,7 +3231,7 @@ packages:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.6.0-dev.20240702
+      typescript: 5.6.0-dev.20240731
     dev: true
 
   /dprint@0.35.4:
@@ -6249,8 +6249,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.6.0-dev.20240702:
-    resolution: {integrity: sha512-hbRazJD/2++Y7fBv6NZtCyoMfoVYmuDlGs+jqdWicZfXP6Fp8q9FDFnuvYpKNq1fXwBrGIUXEZlXssvXIWy/FQ==}
+  /typescript@5.6.0-dev.20240731:
+    resolution: {integrity: sha512-XNueWVxo4buZCEMor0GB/x7ZpzbPzowRNc42fznRinFzGipR+v+Dgelpd6cJvdkN7/TSFASN2M2jQxDeZnk95A==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/src/__tests__/mappings/__snapshots__/apigateway.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/apigateway.spec.ts.snap
@@ -42,7 +42,7 @@ exports[`Apigateway mappings > Should map AWS::ApiGatewayV2::Authorizer 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -94,7 +94,7 @@ exports[`Apigateway mappings > Should map AWS::ApiGatewayV2::DomainName 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -163,7 +163,7 @@ exports[`Apigateway mappings > Should map AWS::ApiGatewayV2::Integration 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -222,7 +222,7 @@ exports[`Apigateway mappings > Should map AWS::ApiGatewayV2::Route 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -289,7 +289,7 @@ exports[`Apigateway mappings > Should map AWS::ApiGatewayV2::Stage 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -328,7 +328,7 @@ exports[`Apigateway mappings > should map AWS::ApiGateway::Account 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -371,7 +371,7 @@ exports[`Apigateway mappings > should map AWS::ApiGateway::BasePathMapping 1`] =
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -411,7 +411,7 @@ exports[`Apigateway mappings > should map AWS::ApiGateway::Deployment 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -451,7 +451,7 @@ exports[`Apigateway mappings > should map AWS::ApiGateway::Stage 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/appsync.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/appsync.spec.ts.snap
@@ -97,7 +97,7 @@ exports[`Appsync mappings > AWS::AppSync::GraphQLApi > Should translate API with
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       },
       \\"time\\": {
         \\"source\\": \\"time\\",
@@ -183,7 +183,7 @@ exports[`Appsync mappings > AWS::AppSync::GraphQLApi > Should translate API with
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -238,7 +238,7 @@ exports[`Appsync mappings > Should translate AWS::AppSync::ApiKey 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -326,7 +326,7 @@ exports[`Appsync mappings > Should translate AWS::AppSync::DataSource 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -366,7 +366,7 @@ exports[`Appsync mappings > Should translate AWS::AppSync::DomainNameApiAssociat
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -435,7 +435,7 @@ exports[`Appsync mappings > Should translate AWS::AppSync::Resolver 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -493,7 +493,7 @@ exports[`Appsync mappings > Should translate AWS::AppSync:FunctionConfiguration 
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/certificate-manager.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/certificate-manager.spec.ts.snap
@@ -63,7 +63,7 @@ exports[`CertificateManager mappings > should map AWS::CertificateManager::Certi
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/cloudfront.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/cloudfront.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`CloudFront > Should map AWS::CloudFront::CloudFrontOriginAccessIdentity
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -265,7 +265,7 @@ exports[`CloudFront > Should map AWS::CloudFront::Distribution 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -394,7 +394,7 @@ exports[`CloudFront > Should map AWS::CloudFront::Distribution 2`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/cognito.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/cognito.spec.ts.snap
@@ -45,7 +45,7 @@ exports[`Cognito mappings > Should map AWS::Cognito::IdentityPool 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -103,7 +103,7 @@ exports[`Cognito mappings > Should map AWS::Cognito::IdentityPoolRoleAttachment 
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -257,7 +257,7 @@ exports[`Cognito mappings > Should map AWS::Cognito::UserPool 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -347,7 +347,7 @@ exports[`Cognito mappings > Should map AWS::Cognito::UserPoolClient 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/dynamodb.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/dynamodb.spec.ts.snap
@@ -26,6 +26,12 @@ exports[`DynamoDB mappings > Should map AWS::DynamoDB::Table 1`] = `
         \\"table_name\\": \\"test-table\\"
       }
     },
+    \\"aws_dynamodb_resource_policy\\": {
+      \\"resource_resource-resource-policy_BB2DAEEF\\": {
+        \\"policy\\": \\"\${jsonencode({\\\\\\"Version\\\\\\" = \\\\\\"2012-10-17\\\\\\", \\\\\\"Statement\\\\\\" = [{\\\\\\"Effect\\\\\\" = \\\\\\"Allow\\\\\\", \\\\\\"Principal\\\\\\" = {\\\\\\"Service\\\\\\" = \\\\\\"dynamodb.amazonaws.com\\\\\\"}, \\\\\\"Action\\\\\\" = \\\\\\"dynamodb:DescribeTable\\\\\\", \\\\\\"Resource\\\\\\" = \\\\\\"*\\\\\\"}]})}\\",
+        \\"resource_arn\\": \\"\${aws_dynamodb_table.resource_22C949BF.arn}\\"
+      }
+    },
     \\"aws_dynamodb_table\\": {
       \\"resource_22C949BF\\": {
         \\"attribute\\": [
@@ -110,7 +116,7 @@ exports[`DynamoDB mappings > Should map AWS::DynamoDB::Table 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/ec2-vpc.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/ec2-vpc.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`EC2 VPC mappings > Should map AWS::EC2::InternetGateway 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -77,7 +77,7 @@ exports[`EC2 VPC mappings > Should map AWS::EC2::Route 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -144,7 +144,7 @@ exports[`EC2 VPC mappings > Should map AWS::EC2::SecurityGroup 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -191,7 +191,7 @@ exports[`EC2 VPC mappings > Should map AWS::EC2::SecurityGroupEgress 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -238,7 +238,7 @@ exports[`EC2 VPC mappings > Should map AWS::EC2::SecurityGroupIngress 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -278,7 +278,7 @@ exports[`EC2 VPC mappings > Should map AWS::EC2::SubnetRouteTableAssociation 1`]
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -325,7 +325,7 @@ exports[`EC2 VPC mappings > Should map AWS::EC2::VPC 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -458,7 +458,7 @@ exports[`EC2 VPC mappings > Should provision all the components of a VPC 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   }

--- a/src/__tests__/mappings/__snapshots__/events.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/events.spec.ts.snap
@@ -143,7 +143,7 @@ exports[`Events mappings > Should map AWS::Events::Rule 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/iam.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/iam.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`IAM Mappings > Should map AWS::IAM::AccessKey 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -85,7 +85,7 @@ exports[`IAM Mappings > should map AWS::IAM::Policy 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -160,7 +160,7 @@ exports[`IAM Mappings > should map AWS::IAM::Role 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       },
       \\"time\\": {
         \\"source\\": \\"time\\",

--- a/src/__tests__/mappings/__snapshots__/lambda.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/lambda.spec.ts.snap
@@ -84,7 +84,7 @@ exports[`Lambda mappings > Should map AWS::Lambda::EventSourceMapping 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -135,7 +135,7 @@ exports[`Lambda mappings > Should map AWS::Lambda::LayerVersion 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -180,7 +180,7 @@ exports[`Lambda mappings > Should map AWS::Lambda::LayerVersionPermission 1`] = 
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -226,7 +226,7 @@ exports[`Lambda mappings > Should map AWS::Lambda::Permission 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -327,7 +327,7 @@ exports[`Lambda mappings > should map CfnFunction to LambdaFunction 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/logs.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/logs.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`Logs mappings > Should map AWS::Logs::LogGroup 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -71,7 +71,7 @@ exports[`Logs mappings > Should map AWS::Logs::ResourcePolicy 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/route53.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/route53.spec.ts.snap
@@ -69,7 +69,7 @@ exports[`Route53 mappings > Should map AWS::Route53::RecordSet 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/s3.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/s3.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`S3 mappings > Should map AWS::S3::BucketPolicy 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/sns.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/sns.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`SNS mappings > AWS:SNS:Subscription > should translate 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -112,7 +112,7 @@ exports[`SNS mappings > AWS:SNS:Topic > Should translate 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/sqs.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/sqs.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`SQS mappings > AWS:SQS:QueuePolicy > should translate to multiple SqsQu
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -74,7 +74,7 @@ exports[`SQS mappings > AWS:SQS:QueuePolicy > should translate to single SqsQueu
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/__snapshots__/stepfunctions.spec.ts.snap
+++ b/src/__tests__/mappings/__snapshots__/stepfunctions.spec.ts.snap
@@ -40,7 +40,7 @@ exports[`Step Functions mappings > AWS:StepFunctions:StateMachine > Should trans
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -101,7 +101,7 @@ exports[`Step Functions mappings > AWS:StepFunctions:StateMachine > Should trans
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -154,7 +154,7 @@ exports[`Step Functions mappings > AWS:StepFunctions:StateMachine > Should trans
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },
@@ -215,7 +215,7 @@ exports[`Step Functions mappings > AWS:StepFunctions:StateMachine > Should trans
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"5.40.0\\"
+        \\"version\\": \\"5.60.0\\"
       }
     }
   },

--- a/src/__tests__/mappings/dynamodb.spec.ts
+++ b/src/__tests__/mappings/dynamodb.spec.ts
@@ -47,6 +47,21 @@ describe("DynamoDB mappings", () => {
                     },
                 },
             ],
+            resourcePolicy: {
+                policyDocument: {
+                    Version: "2012-10-17",
+                    Statement: [
+                        {
+                            Effect: "Allow",
+                            Principal: {
+                                Service: "dynamodb.amazonaws.com",
+                            },
+                            Action: "dynamodb:DescribeTable",
+                            Resource: "*",
+                        },
+                    ],
+                },
+            },
             keySchema: [
                 {
                     attributeName: "test-attribute-name",

--- a/src/mappings/services/dynamodb.ts
+++ b/src/mappings/services/dynamodb.ts
@@ -1,13 +1,17 @@
 import { DynamodbContributorInsights } from "@cdktf/provider-aws/lib/dynamodb-contributor-insights/index.js";
 import { DynamodbKinesisStreamingDestination } from "@cdktf/provider-aws/lib/dynamodb-kinesis-streaming-destination/index.js";
+import { DynamodbResourcePolicy } from "@cdktf/provider-aws/lib/dynamodb-resource-policy";
 import { DynamodbTable, DynamodbTableConfig } from "@cdktf/provider-aws/lib/dynamodb-table/index.js";
 import { Names } from "aws-cdk-lib";
 import { CfnTable } from "aws-cdk-lib/aws-dynamodb";
+import { Fn } from "cdktf";
+import { ImplicitDependencyAspect } from "../implicit-dependency-aspect.js";
 import { deleteUndefinedKeys, registerMappingTyped } from "../utils.js";
 
 export function registerDynamoDBMappings() {
     registerMappingTyped(CfnTable, DynamodbTable, {
         resource(scope, id, tableProps) {
+            tableProps.O;
             const globalIndexInsights: string[] = [];
             const mapped: DynamodbTableConfig = {
                 name: tableProps.TableName!,
@@ -79,30 +83,53 @@ export function registerDynamoDBMappings() {
             table.name = mapped.name || Names.uniqueResourceName(table, {
                 maxLength: 64,
             });
+            const implicitDependencies = [];
 
             if (tableProps.KinesisStreamSpecification) {
-                new DynamodbKinesisStreamingDestination(scope, `${id}-kinesis-streaming-destination`, {
-                    streamArn: tableProps.KinesisStreamSpecification.StreamArn as string,
-                    tableName: mapped.name,
-                });
+                implicitDependencies.push(
+                    new DynamodbKinesisStreamingDestination(scope, `${id}-kinesis-streaming-destination`, {
+                        streamArn: tableProps.KinesisStreamSpecification.StreamArn as string,
+                        tableName: mapped.name,
+                    }),
+                );
             }
 
             for (const index of globalIndexInsights) {
-                new DynamodbContributorInsights(scope, `${id}-${index}-contributor-insights`, {
-                    tableName: mapped.name,
-                    indexName: index,
-                });
+                implicitDependencies.push(
+                    new DynamodbContributorInsights(scope, `${id}-${index}-contributor-insights`, {
+                        tableName: mapped.name,
+                        indexName: index,
+                    }),
+                );
             }
 
             if (tableProps.ContributorInsightsSpecification) {
-                new DynamodbContributorInsights(scope, `${id}-contributor-insights`, {
-                    tableName: mapped.name,
-                });
+                implicitDependencies.push(
+                    new DynamodbContributorInsights(scope, `${id}-contributor-insights`, {
+                        tableName: mapped.name,
+                    }),
+                );
             }
 
+            if (tableProps.ResourcePolicy) {
+                implicitDependencies.push(
+                    new DynamodbResourcePolicy(scope, `${id}-resource-policy`, {
+                        policy: Fn.jsonencode(tableProps.ResourcePolicy.PolicyDocument),
+                        resourceArn: table.arn,
+                    }),
+                );
+            }
+
+            if (implicitDependencies.length > 0) {
+                ImplicitDependencyAspect.of(table, implicitDependencies);
+            }
             return table;
         },
-        unsupportedProps: [],
+        unsupportedProps: [
+            // Support for this property is tracked by this issue
+            // https://github.com/hashicorp/terraform-provider-aws/issues/37256
+            "OnDemandThroughput",
+        ],
         attributes: {
             Arn: resource => resource.arn,
             StreamArn: resource => resource.streamArn,

--- a/src/mappings/services/s3.ts
+++ b/src/mappings/services/s3.ts
@@ -51,7 +51,6 @@ export function registerS3Mappings() {
                     bucket: props?.BucketName,
                     acl: props?.AccessControl,
                     accelerationStatus: props?.AccelerateConfiguration?.AccelerationStatus,
-                    name: props?.BucketName,
                     objectLockEnabled: props?.ObjectLockEnabled,
                     tags: Object.fromEntries(
                         props?.Tags?.map(({


### PR DESCRIPTION
### Problem

Cloudformation added the ability to set a resource policy for dynamodb tables, but this is not supported by the adaptor

### Solution

Add support. This requires updating the required version of aws-cdk-lib and @cdktf/provider-aws

#### Test Plan:
- [ ] Covered by existing tests
- [x] New coverage added
- [ ] Special instructions for testing described below

<!--- Describe how to test this PR -->

#### Documentation:
- [x] No documentation required
- [ ] Additional documentation required below

<!--- Describe any additional documentation required -->

#### Additional Notes:

N/A <!--- Describe any additional notes or context -->
